### PR TITLE
Allow consumers of i18next to set normalizeLng()

### DIFF
--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -87,7 +87,7 @@
                 }
 
                 lang = parts[0];
-                if (options.normalizeLng) {
+                if (lang && options.normalizeLng) {
                     lang = options.normalizeLng(lang);
                 }
 

--- a/lib/i18nextWrapper.js
+++ b/lib/i18nextWrapper.js
@@ -73,6 +73,7 @@
             // associate language tags by their 'q' value (between 1 and 0)
             acceptLanguage.split(',').forEach(function(l) {
                 var parts = l.split(';'); // 'en-GB;q=0.8' -> ['en-GB', 'q=0.8']
+                var lang;
 
                 // get the language tag qvalue: 'q=0.8' -> 0.8
                 var qvalue = 1; // default qvalue
@@ -85,8 +86,13 @@
                     }
                 }
 
+                lang = parts[0];
+                if (options.normalizeLng) {
+                    lang = options.normalizeLng(lang);
+                }
+
                 // add the tag and primary subtag to the qvalue associations
-                lngs.push({lng: cleanLngString(parts[0], options), q: qvalue});
+                lngs.push({lng: cleanLngString(lang, options), q: qvalue});
             });
 
             lngs.sort(function(a,b) {


### PR DESCRIPTION
Usage:
```
i18n.init({
  ...
  normalizeLng: function(lang) {
    if (!lang || !_.isString(lang)) {
      return lang;
    }

    return lang.replace('-', '_');
  }
});
```